### PR TITLE
Fixes #12 Missing variables on string formatting

### DIFF
--- a/command.py
+++ b/command.py
@@ -943,7 +943,7 @@ class MetricShell(Cmd):
       length, paths = self.simulation.path(a,b)
 
       if not length and not paths:
-         print "No valid path from %s to %s in model"
+         print "No valid path from %s to %s in model" % (a, b)
          return
       
       print "Path from %s to %s:"\
@@ -1130,7 +1130,7 @@ class MetricShell(Cmd):
       length, paths = self.model.path(a,b)
 
       if not length and not paths:
-         print "No valid path from %s to %s in model"
+         print "No valid path from %s to %s in model" % (a, b)
          return
       
       print "Path from %s to %s:"\


### PR DESCRIPTION
In the "No valid path" strings it prints %s instead of node names